### PR TITLE
fix Escape key dose not fire by onKeyPress

### DIFF
--- a/src/App/TodoList/Item/index.test.tsx
+++ b/src/App/TodoList/Item/index.test.tsx
@@ -81,14 +81,25 @@ test('should work edit mode and toggle show/hide', () => {
   fireEvent.change(screen.getByTestId('todo-edit-input'), {
     target: { value: 'cut tomato plus' },
   })
-  fireEvent.keyPress(screen.getByTestId('todo-edit-input'), {
-    key: 'Enter',
-    code: 13,
-    charCode: 13, // I had issue that doesn't trigger keyPress event relevant charCode. https://github.com/testing-library/react-testing-library/issues/269
-  })
+  fireEvent.keyDown(screen.getByTestId('todo-edit-input'), { key: 'Enter' })
 
   expect(screen.getByTestId('todo-body-text')).toHaveTextContent(
     'cut tomato plus'
+  )
+  expect(screen.getByTestId('todo-item')).not.toHaveClass('editing')
+  expect(screen.getByTestId('todo-edit-input')).not.toBeVisible()
+
+  // double click todo text label, then focus and enable todo text edit code
+  fireEvent.doubleClick(screen.getByTestId('todo-body-text'))
+  expect(screen.getByTestId('todo-item')).toHaveClass('editing')
+  expect(screen.getByTestId('todo-edit-input')).toBeVisible()
+  expect(screen.getByTestId('todo-edit-input')).toHaveFocus()
+  fireEvent.change(screen.getByTestId('todo-edit-input'), {
+    target: { value: 'cut tomato plus plus' },
+  })
+  fireEvent.keyDown(screen.getByTestId('todo-edit-input'), { key: 'Escape' })
+  expect(screen.getByTestId('todo-body-text')).toHaveTextContent(
+    'cut tomato plus plus'
   )
   expect(screen.getByTestId('todo-item')).not.toHaveClass('editing')
   expect(screen.getByTestId('todo-edit-input')).not.toBeVisible()

--- a/src/App/TodoList/Item/index.tsx
+++ b/src/App/TodoList/Item/index.tsx
@@ -134,7 +134,7 @@ const Item: React.FC<Props> = ({ todo }) => {
           className="edit"
           value={todo.bodyText}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleTodoTextEdit(e, todo.id)} /* eslint-disable-line prettier/prettier */
-          onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => submitEditText(e)} /* eslint-disable-line prettier/prettier */
+          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => submitEditText(e)} /* eslint-disable-line prettier/prettier */
           data-cy="todo-edit-input"
           data-testid="todo-edit-input"
         />


### PR DESCRIPTION
When double click the Todo item > edit > press Escape key, nothing is changed, because the `Escape` key dose not fire by `keypress` event, check this link

[https://stackoverflow.com/questions/47849060/capturing-escape-keypress-in-reactjs](https://stackoverflow.com/questions/47849060/capturing-escape-keypress-in-reactjs)

But we can use `keydown` or `keyup` event to avoid this issue